### PR TITLE
Clean up screen output

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -13,7 +13,6 @@
 #    limitations under the License.
 
 import sys
-from pprint import pprint
 import time
 import logging
 import functools
@@ -146,6 +145,22 @@ def factor(P):
 
     return output
 
+def display_output(output):
+    header_str = 'Factors    Valid?  Percentage of occurences'
+    total_width = 80  # Assumed total console width
+    # Width available to draw bars:
+    available_width = total_width - header_str.index('P') - 4
+
+    print('-'*len(header_str))
+    print(header_str)
+    print('-'*len(header_str))
+
+    for result in output['Results']:
+        percentage = result['Percentage of results']
+        print('({:3},{:3})  {:3}     {:3.0f} '.format(result['a'], result['b'], 'Yes' if result['Valid'] else '', percentage), end='')
+        nbars = int(percentage/100 * available_width)
+        print('#' * nbars)
+
 
 if __name__ == '__main__':
     # get input from user
@@ -157,4 +172,4 @@ if __name__ == '__main__':
     output = factor(P)
 
     # output results
-    pprint(output)
+    display_output(output)

--- a/demo.py
+++ b/demo.py
@@ -146,7 +146,7 @@ def factor(P):
     return output
 
 def display_output(output):
-    header_str = 'Factors    Valid?  Percentage of occurences'
+    header_str = 'Factors    Valid?  Percentage of occurrences'
     total_width = 80  # Assumed total console width
     # Width available to draw bars:
     available_width = total_width - header_str.index('P') - 4

--- a/demo.py
+++ b/demo.py
@@ -146,20 +146,23 @@ def factor(P):
     return output
 
 def display_output(output):
-    header_str = 'Factors    Valid?  Percentage of occurrences'
+    header1_str = 'Factors    Valid?  Percentage of Occurrences'
+    header2_str = ' ' * header1_str.index('P') + 'Numeric & Graphic Representation'
     total_width = 80  # Assumed total console width
     # Width available to draw bars:
-    available_width = total_width - header_str.index('P') - 4
+    available_width = total_width - header1_str.index('P') - 4
 
-    print('-'*len(header_str))
-    print(header_str)
-    print('-'*len(header_str))
+    header_len = max(len(header1_str), len(header2_str))
+    print('-'*header_len)
+    print(header1_str)
+    print(header2_str)
+    print('-'*header_len)
 
     for result in output['Results']:
         percentage = result['Percentage of results']
         print('({:3},{:3})  {:3}     {:3.0f} '.format(result['a'], result['b'], 'Yes' if result['Valid'] else '', percentage), end='')
         nbars = int(percentage/100 * available_width)
-        print('#' * nbars)
+        print('*' * nbars)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of printing the full output dictionary, which spans many
lines, print a formatted table showing the identified factors, whether
they are valid, the percentage occurrence and a pseudo bar-chart
representing occurrence.

Closes #23.

Previous output was extremely verbose and difficult to parse visually.  New output looks like:
```
Enter a number to be factored:
Input product        ( 0 <= P <= 63): 24
Running on QPU
--------------------------------------------
Factors    Valid?  Percentage of occurrences
--------------------------------------------
(  6,  4)  Yes      12 ######
(  4,  6)  Yes       2 #
(  7,  4)            5 ##
(  4,  7)            1 
(  5,  4)            1 
(  4,  5)            5 ##
(  4,  4)            5 ##
(  6,  7)            3 #
(  3,  6)            3 #
(  6,  3)            3 #
(  6,  6)           12 ######
(  6,  5)            5 ##
(  2,  7)            7 ###
(  3,  4)            7 ###
(  6,  2)            2 #
(  2,  6)            7 ###
(  4,  3)            2 #
(  2,  3)            2 #
(  2,  4)            2 #
(  1,  4)            1 
(  0,  3)            1 
(  7,  2)            2 #
(  2,  5)            4 ##
(  2,  2)            1 
(  4,  0)            1 
(  0,  0)            1 
(  5,  6)            1 
(  0,  7)            1 
(  6,  0)            1 
```
